### PR TITLE
Make text "No saved credit cards." translatable

### DIFF
--- a/view/frontend/templates/saved_credit_card.phtml
+++ b/view/frontend/templates/saved_credit_card.phtml
@@ -61,5 +61,5 @@ if ($collection->getSize() > 0) {
         {"*": {"SDM_Altapay/js/Altapay": {}}}
     </script>
 <?php } else { ?>
-    <div class="message info empty"><span>No saved credit cards.</span></div>
+    <div class="message info empty"><span><?= $block->escapeHtml(__('No saved credit cards.')); ?></span></div>
 <?php } ?>


### PR DESCRIPTION
The message "No saved credit cards." shown in customer account page is not translatable.  This will make it translatable. 
We should not need to create theme override of saved_credit_card.phtml just to make this text translatable.