### PR TITLE
Resolving cancel order issues when there is no transaction

### DIFF
--- a/Observer/OrderCancelObserver.php
+++ b/Observer/OrderCancelObserver.php
@@ -47,7 +47,7 @@ class OrderCancelObserver implements ObserverInterface
         /** @var \Magento\Sales\Model\Order\Payment $payment */
         $payment = $order->getPayment();
 
-        if (in_array($payment->getMethod(), SystemConfig::getTerminalCodes())) {
+        if (in_array($payment->getMethod(), SystemConfig::getTerminalCodes()) && $payment->getLastTransId()) {
             $api = new ReleaseReservation($this->systemConfig->getAuth($order->getStore()->getCode()));
             $api->setTransaction($payment->getLastTransId());
             /** @var ReleaseReservationResponse $response */


### PR DESCRIPTION
#35 
adding additional check on OrderCancelObserver to check if there is a transaction created